### PR TITLE
Add testcase and fix for indentation bug

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,13 +3,13 @@
     "version" : "*",
     "description" : "Simple tracing and debugging support for Perl 6 grammars",
     "build-depends" : [
-        "Term::ANSIColor"
+        "Terminal::ANSIColor"
     ],
     "test-depends" : [
         "Test"
     ],
     "depends" : [
-        "Term::ANSIColor"
+        "Terminal::ANSIColor"
     ],
     "provides" : {
         "Grammar::Tracer" : "lib/Grammar/Tracer.pm",

--- a/lib/Grammar/Debugger.pm
+++ b/lib/Grammar/Debugger.pm
@@ -1,4 +1,4 @@
-use Term::ANSIColor;
+use Terminal::ANSIColor;
 
 # On Windows you can use perl 5 to get proper output:
 # - send through Win32::Console::ANSI: perl6 MyGrammar.pm | perl -e "use Win32::Console::ANSI; print while (<>)"

--- a/lib/Grammar/Tracer.pm
+++ b/lib/Grammar/Tracer.pm
@@ -1,4 +1,4 @@
-use Term::ANSIColor;
+use Terminal::ANSIColor;
 
 # On Windows you can use perl 5 to get proper output:
 # - send through Win32::Console::ANSI: perl6 MyGrammar.pm | perl -e "use Win32::Console::ANSI; print while (<>)"


### PR DESCRIPTION
Grammar::Tracer gets kinda confused if a traced `.parse` throws an exception followed by another trace in the same process.

This fix doesn't appear to have any unwanted side effects, though I haven't tried it with anything crazy.