### PR TITLE
fixes deprecated test sub names, lives_ok => lives-ok

### DIFF
--- a/t/debugger.t
+++ b/t/debugger.t
@@ -11,7 +11,7 @@ grammar Sample {
     token foo { x }
 }
 
-lives_ok
+lives-ok
     {
         my $*OUT = class { method say(*@x) { }; method print(*@x) { }; method flush(*@x) { } };
         my $*IN  = class { method get(*@x) { '' } };

--- a/t/tracer.t
+++ b/t/tracer.t
@@ -11,7 +11,7 @@ grammar Sample {
     token foo { x }
 }
 
-lives_ok
+lives-ok
     {
         my $*OUT = class { method say(*@x) { }; method print(*@x) { }; method flush(*@x) { } }
         Sample.parse('x')


### PR DESCRIPTION
Simple change to eliminate some deprecation warnings because of test sub having underscores rather than hyphens.