### PR TITLE
Update Term::ANSIColor dep to Terminal::ANSIColor

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,13 +3,13 @@
     "version" : "*",
     "description" : "Simple tracing and debugging support for Perl 6 grammars",
     "build-depends" : [
-        "Term::ANSIColor"
+        "Terminal::ANSIColor"
     ],
     "test-depends" : [
         "Test"
     ],
     "depends" : [
-        "Term::ANSIColor"
+        "Terminal::ANSIColor"
     ],
     "provides" : {
         "Grammar::Tracer" : "lib/Grammar/Tracer.pm",

--- a/lib/Grammar/Debugger.pm
+++ b/lib/Grammar/Debugger.pm
@@ -1,4 +1,4 @@
-use Term::ANSIColor;
+use Terminal::ANSIColor;
 
 # On Windows you can use perl 5 to get proper output:
 # - send through Win32::Console::ANSI: perl6 MyGrammar.pm | perl -e "use Win32::Console::ANSI; print while (<>)"

--- a/lib/Grammar/Tracer.pm
+++ b/lib/Grammar/Tracer.pm
@@ -1,4 +1,4 @@
-use Term::ANSIColor;
+use Terminal::ANSIColor;
 
 # On Windows you can use perl 5 to get proper output:
 # - send through Win32::Console::ANSI: perl6 MyGrammar.pm | perl -e "use Win32::Console::ANSI; print while (<>)"


### PR DESCRIPTION
The module was renamed to the latter, the former spits out a deprecation message on use now.