### PR TITLE
unbreak the debugger

### DIFF
--- a/lib/Grammar/Debugger.pm
+++ b/lib/Grammar/Debugger.pm
@@ -49,6 +49,7 @@ my class DebuggedGrammarHOW is Metamodel::GrammarHOW {
     method find_method($obj, $name) {
         my $meth := callsame;
         return $meth if $meth.WHAT.^name eq 'NQPRoutine';
+        return $meth unless $meth ~~ Any;
         return $meth unless $meth ~~ Regex;
         return -> $c, |args {
             # Issue the rule's/token's/regex's name

--- a/lib/Grammar/Tracer.pm
+++ b/lib/Grammar/Tracer.pm
@@ -10,6 +10,7 @@ my class TracedGrammarHOW is Metamodel::GrammarHOW {
     method find_method($obj, $name) {
         my $meth := callsame;
         return $meth if $meth.WHAT.^name eq 'NQPRoutine';
+        return $meth unless $meth ~~ Any;
         return $meth unless $meth ~~ Regex;
         return -> $c, |args {
             # Method name.


### PR DESCRIPTION
A rakudo patch that is meant to make autothreading of junctions
work on the LHS of a smartmatch forces us to care about Mu/Any.

See: https://github.com/rakudo/rakudo/commit/5d83db