### PR TITLE
Fix indentation level not being reset between parses when exceptions are thrown

### DIFF
--- a/lib/Grammar/Tracer.pm6
+++ b/lib/Grammar/Tracer.pm6
@@ -49,6 +49,7 @@ my class TracedGrammarHOW is Metamodel::GrammarHOW does Grammar::Debugger::WrapC
 		    $result := $meth($c, |args);
 		    CATCH {
 		        say "Caught and rethrowing exception $_";
+                        $indent--;
 		    }
 		}
                 $indent--;

--- a/lib/Grammar/Tracer.pm6
+++ b/lib/Grammar/Tracer.pm6
@@ -44,7 +44,12 @@ my class TracedGrammarHOW is Metamodel::GrammarHOW does Grammar::Debugger::WrapC
 
                 # Call rule.
                 $indent++;
-                my $result := $meth($c, |args);
+                try {
+		    my $result := $meth($c, |args);
+		    CATCH {
+		        say "Caught and rethrowing exception $_";
+		    }
+		}
                 $indent--;
 
                 # Dump result.

--- a/lib/Grammar/Tracer.pm6
+++ b/lib/Grammar/Tracer.pm6
@@ -44,13 +44,13 @@ my class TracedGrammarHOW is Metamodel::GrammarHOW does Grammar::Debugger::WrapC
 
                 # Call rule.
                 $indent++;
-		my $result;
+                my $result;
                 try {
-		    $result := $meth($c, |args);
-		    CATCH {
+                    $result := $meth($c, |args);
+                    CATCH {
                         $indent--;
-		    }
-		}
+                    }
+                }
                 $indent--;
 
                 # Dump result.

--- a/lib/Grammar/Tracer.pm6
+++ b/lib/Grammar/Tracer.pm6
@@ -48,7 +48,6 @@ my class TracedGrammarHOW is Metamodel::GrammarHOW does Grammar::Debugger::WrapC
                 try {
 		    $result := $meth($c, |args);
 		    CATCH {
-		        say "Caught and rethrowing exception $_";
                         $indent--;
 		    }
 		}

--- a/lib/Grammar/Tracer.pm6
+++ b/lib/Grammar/Tracer.pm6
@@ -44,8 +44,9 @@ my class TracedGrammarHOW is Metamodel::GrammarHOW does Grammar::Debugger::WrapC
 
                 # Call rule.
                 $indent++;
+		my $result;
                 try {
-		    my $result := $meth($c, |args);
+		    $result := $meth($c, |args);
 		    CATCH {
 		        say "Caught and rethrowing exception $_";
 		    }


### PR DESCRIPTION
The parse output can sometimes start with a line like `|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  TOP` when there have been some exceptions thrown during indented parse levels before the current parse. This patch makes the indentation go back to normal.