### PR TITLE
Added the ability to toggle tracer output at runtime. 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,5 +29,10 @@ Once again, after a use:
 
 It will apply to any grammars in the lexical scope of the use statement.
 
+The default behavior of this module is to output traces for all grammars as they are parsed.  The function GrammarTraceMode() is exported to allow this behavior to be changed at runtime.
+
+    GrammarTraceMode(Always) # Default, always output full traces
+    GrammarTraceMode(Never)  # Disable all Grammar Tracing
+
 # Bugs? Ideas?
 Please file them in [GitHub issues](https://github.com/jnthn/grammar-debugger/issues).


### PR DESCRIPTION
This exports a new function from the Grammar::Trace class, "GrammarTraceMode($mode)", to allow toggling trace output at runtime.  Supported options are Always (default, matching existing behavior), Never, or Error.  In the latter case, the trace will be output only if the Grammar failed to find a match.

This commit builds upon changes made by nkh to cleanup rendering, though that discrete commit has been squashed due to merge conflicts.